### PR TITLE
8.60 monsters

### DIFF
--- a/data/monster/monsters/dragon lord.xml
+++ b/data/monster/monsters/dragon lord.xml
@@ -49,7 +49,9 @@
 		<voice sentence="YOU WILL BURN!" yell="1" />
 	</voices>
 	<loot>
-		<item name="gold coin" countmax="245" chance="95000" />
+		<item name="gold coin" countmax="100" chance="95000" />
+		<item name="gold coin" countmax="100" chance="95000" />
+		<item name="gold coin" countmax="45" chance="95000" />
 		<item name="dragon ham" countmax="5" chance="80000" />
 		<item name="green mushroom" chance="12000" />
 		<item name="royal spear" countmax="3" chance="9000" />

--- a/data/monster/monsters/elf arcanist.xml
+++ b/data/monster/monsters/elf arcanist.xml
@@ -57,7 +57,7 @@
 		<item id="1949" chance="31000"/><!-- scroll -->
 		<item id="2260" chance="16000"/><!-- blank rune -->
 		<item id="2401" chance="11500"/><!-- staff -->
-		<item id="2642" chance="135000"/><!-- sandals -->
+		<item id="2642" chance="100000"/><!-- sandals -->
 		<item id="2682" chance="19000"/><!-- melon -->
 		<item id="2689" chance="14000"/><!-- bread -->
 		<item id="2652" chance="7250"/><!-- green tunic -->


### PR DESCRIPTION
Resolves 2 warnings:

```
[Warning - Monsters::loadMonster] Invalid "countmax" 245 used for loot, the max allowed value is 100.
[Warning - Monsters::loadMonster] Invalid "chance" 135000 used for loot, the max is 100000.
```