### PR TITLE
combustion - setParameter typo

### DIFF
--- a/data/spells/scripts/custom/combustion.lua
+++ b/data/spells/scripts/custom/combustion.lua
@@ -1,5 +1,5 @@
 local condition = Condition(CONDITION_FIRE)
-condition:setParameterCONDITION_PARAM_DELAYED, 1)
+condition:setParameter(CONDITION_PARAM_DELAYED, 1)
 condition:addDamage(5, 3000, -25)
 condition:addDamage(1, 5000, -666)
 


### PR DESCRIPTION
saw this typo while scrolling through https://github.com/nekiro/TFS-1.4-Downgrades/commit/8002dc9cb3d76560fadb62ed0f8d3de1562ac642

i wonder what else happend