### PR TITLE
EventCallback Setting new default order

### DIFF
--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -90,15 +90,11 @@ EventCallback = {
 		if isScriptsInterface() then
 			local type, call = rawget(self, "type"), rawget(self, "call")
 			if type and call then
-				index = tonumber(index)
-				EventCallbackData[type][#EventCallbackData[type] + 1] = {call, index or -math.huge}
-				if index then
-					table.sort(EventCallbackData[type], function (a, b) return a[2] < b[2] end)
-				end
+				EventCallbackData[type][#EventCallbackData[type] + 1] = {call, tonumber(index) or 0}
+				table.sort(EventCallbackData[type], function (a, b) return a[2] < b[2] end)
 				return rawset(self, "type", nil) and rawset(self, "call", nil)
-			else
-				debugPrint("[Warning - EventCallback::register] is need to set up a callback before register.")
 			end
+			debugPrint("[Warning - EventCallback::register] is need to set up a callback before register.")
 		end
 	end,
 	clear = function (self)
@@ -130,11 +126,9 @@ setmetatable(EventCallback, {
 		for k, ev in pairs(eventTable) do
 			ret = {ev[1](unpack(args))}
 			if k == events or (ret[1] ~= nil and (ret[1] == false or table.contains({EVENT_CALLBACK_ONAREACOMBAT, EVENT_CALLBACK_ONTARGETCOMBAT}, type) and ret[1] ~= RETURNVALUE_NOERROR)) then
-			return unpack(ret)
+				return unpack(ret)
 			end
-			for k, v in pairs(auxargs[type] or {}) do
-				args[k] = ret[v]
-			end
+			for k, v in pairs(auxargs[type] or {}) do args[k] = ret[v] end
 		end
 	end
 	})


### PR DESCRIPTION
Since in the main repository this file was updated with some small changes in the order of execution of the callbacks, I assumed that here it should also be done so that any Revscript + EventCallback is consistent.
https://github.com/otland/forgottenserver/pull/3413

I will not deny that I also want to appear here:
![image](https://user-images.githubusercontent.com/28090948/117865473-ffea8c80-b263-11eb-872a-c09650ae0f48.png)
:V