### PR TITLE
Fix display remaining premium days in character list

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -78,7 +78,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 	if (g_config.getBoolean(ConfigManager::FREE_PREMIUM)) {
 		output->add<uint16_t>(0xFFFF); //client displays free premium
 	} else {
-		output->add<uint16_t>(account.premiumEndsAt - time(nullptr) / 86400);
+		output->add<uint16_t>((account.premiumEndsAt - time(nullptr)) / 86400);
 	}
 
 	send(output);


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.


**Protocol version**
8.60

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
This resolves a small math error, division calculations takes priority over abstractions, so we use parethesis to ensure the abstractions are calculated before we divide the remaining seconds to figure out how many days are remaining.

from:
![image](https://user-images.githubusercontent.com/1552144/126086705-9113b9db-1628-4dd0-917d-8e1aa2bbdd98.png)

to:
![image](https://user-images.githubusercontent.com/1552144/126086687-d00dde55-5613-463c-b60b-f35214a6d94d.png)

**Issues addressed:** <!-- Write here the issue number, if any. -->None


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
