### PR TITLE
Fix monster definitions

### DIFF
--- a/data/monster/Bosses/ashmunrah.xml
+++ b/data/monster/Bosses/ashmunrah.xml
@@ -45,8 +45,8 @@
 		</defense>
 	</defenses>
 	<summons maxSummons="4">
-		<summon name="ancient scarab" chance="2000" max="2"/>
-		<summon name="green djinn" chance="1000" max="2"/>
+		<summon name="ancient scarab" chance="20" max="2"/>
+		<summon name="green djinn" chance="10" max="2"/>
 	</summons>
 	<elements>
 		<element earthPercent="100"/>

--- a/data/monster/Bosses/mahrdis.xml
+++ b/data/monster/Bosses/mahrdis.xml
@@ -19,8 +19,9 @@
 	</flags>
 	<attacks>
 		<attack name="melee" min="-100" max="-400" poison="65"/>
-		<attack name="physical" interval="1600" chance="7" range="1" min="-60" max="-600"/>
+		<attack name="physical" interval="1600" chance="7" range="1" min="-60" max="-600">
 			<attribute key="areaEffect" value="redshimmer"/>	
+		</attack>
 		<attack name="fire" chance="7" range="7" min="-60" max="-600">
 			<attribute key="shootEffect" value="fire"/>
 			<attribute key="areaEffect" value="firearea"/>

--- a/data/monster/Bosses/morguthis.xml
+++ b/data/monster/Bosses/morguthis.xml
@@ -39,7 +39,7 @@
 		</defense>
 	</defenses>
 	<summons maxSummons="3">
-		<summon name="hero" chance="1000" max="3"/>
+		<summon name="hero" chance="10" max="3"/>
 	</summons>
 	<elements>
 		<element earthPercent="100"/>

--- a/data/monster/Bosses/omruc.xml
+++ b/data/monster/Bosses/omruc.xml
@@ -41,7 +41,7 @@
 		</defense>
 	</defenses>
 	<summons maxSummons="4">
-		<summon name="stalkers" chance="1000"/>
+		<summon name="stalker" chance="10" max="4" />
 	</summons>
 	<elements>
 		<element firePercent="100"/>

--- a/data/monster/Bosses/thalas.xml
+++ b/data/monster/Bosses/thalas.xml
@@ -41,7 +41,7 @@
 		</defense>
 	</defenses>
 	<summons maxSummons="8">
-		<summon name="slime2" chance="3000" max="8"/>
+		<summon name="slime2" chance="30" max="8"/>
 	</summons>
 	<elements>
 		<element earthPercent="100"/>

--- a/data/spells/scripts/runes/explosion_rune.lua
+++ b/data/spells/scripts/runes/explosion_rune.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_EXPLOSIONAREA)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EXPLOSION)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setArea(createCombatArea(AREA_CROSS1X1))
 

--- a/data/spells/scripts/runes/explosion_rune.lua
+++ b/data/spells/scripts/runes/explosion_rune.lua
@@ -1,7 +1,7 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_EXPLOSIONAREA)
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_FIRE)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EXPLOSION)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setArea(createCombatArea(AREA_CROSS1X1))
 


### PR DESCRIPTION
Fixed stalker name typo in summon definition.
Some boss monsters also had summon chance set to value*100 which printed errors in console because value was >1000.
Also fixed mahrdis.xml attack missing a closing xml tag